### PR TITLE
[CHORE] 깃허브 활동 기반 슬랙 알림 자동화

### DIFF
--- a/.github/workflows/slack-pr-notify.yml
+++ b/.github/workflows/slack-pr-notify.yml
@@ -1,0 +1,51 @@
+name: 새로운 PR 생성 시 슬랙에 알림 보내기
+
+on:
+  pull_request:
+    types: [ opened, reopened ]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 슬랙에 알림 전송
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "🆕 *새로운 PR이 작성되었습니다* 🆕"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*PR 제목:* ${{ github.event.pull_request.title }}"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "PR 확인",
+                      "emoji": true
+                    },
+                    "url": "${{ github.event.pull_request.html_url }}",
+                    "action_id": "button_click"
+                  }
+                },
+                {
+                  "type": "divider"
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/slack-review-notify.yml
+++ b/.github/workflows/slack-review-notify.yml
@@ -1,0 +1,64 @@
+name: 새로운 리뷰 생성 시 슬랙에 알림 보내기
+
+on:
+  pull_request_review:
+    types: [ submitted ]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 환경변수 설정
+        run: |
+          BODY=$(echo "${{ github.event.review.body }}" | sed ':a;N;$!ba;s/\r//g;s/\n/\\n/g')
+          echo "BODY=$BODY" >> $GITHUB_ENV
+          echo "URL=${{ github.event.review.html_url }}" >> $GITHUB_ENV
+
+      - name: 슬랙에 알림 전송
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "💬 *새로운 리뷰가 작성되었습니다* 💬"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*PR 제목:* ${{ github.event.pull_request.title }}"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "PR 확인",
+                      "emoji": true
+                    },
+                    "url": "${{ env.URL }}",
+                    "action_id": "button_click"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "\n${{ env.BODY }}"
+                  }
+                },
+                {
+                  "type": "divider"
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## 👀 관련 이슈
close #2 

## ⭐️ 작업 내용
깃허브 활동을 기반으로 슬랙에 알림을 전송하는 봇을 생성하였습니다.
1. '알리미'라는 이름의 슬랙 앱 생성 & Incoming webhook 설정

    > Incoming webhooks are a simple way to post messages from external sources into Slack.

2. 깃허브 레포지토리에 슬랙 webhook 연결
3. Github Actions 스크립트 작성

## 🫧 기타
[개인 레포지토리](https://github.com/helenason/slack-alarm-test)에서 작업 완료한 상태입니다.