### PR TITLE
[FIX] 순환 노선에서의 엣지케이스 보완을 위해 지하철 방향 및 경유역 정보 조회를 위한 API 도입

### DIFF
--- a/src/main/java/com/easyride/subway/client/dataseoul/DataSeoulResponseConverter.java
+++ b/src/main/java/com/easyride/subway/client/dataseoul/DataSeoulResponseConverter.java
@@ -2,7 +2,7 @@ package com.easyride.subway.client.dataseoul;
 
 import com.easyride.global.exception.EasyRideException;
 import com.easyride.subway.client.dto.DataSeoulErrorResponse;
-import com.easyride.subway.client.dto.DataSeoulRealTimeSubwayPositionResponse;
+import com.easyride.subway.client.dto.DataSeoulRealTimeSubwayResponse;
 import com.easyride.subway.exception.SubwayErrorCode;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -32,7 +32,7 @@ public class DataSeoulResponseConverter {
         return INSTANCE;
     }
 
-    public DataSeoulRealTimeSubwayPositionResponse convert(ConvertibleClientHttpResponse response) throws IOException {
+    public DataSeoulRealTimeSubwayResponse convert(ConvertibleClientHttpResponse response) throws IOException {
         if (response.getStatusCode().isError()) {
             throw new EasyRideException(SubwayErrorCode.DATA_SEOUL_API_ERROR);
         }
@@ -44,7 +44,7 @@ public class DataSeoulResponseConverter {
         if (isError(errorResponse)) { // TODO 로깅
             throw new EasyRideException(SubwayErrorCode.DATA_SEOUL_API_ERROR);
         }
-        return OBJECT_MAPPER.readValue(responseBody, DataSeoulRealTimeSubwayPositionResponse.class);
+        return OBJECT_MAPPER.readValue(responseBody, DataSeoulRealTimeSubwayResponse.class);
     }
 
     private DataSeoulErrorResponse extractErrorResponse(String responseBody) throws IOException {

--- a/src/main/java/com/easyride/subway/client/dataseoul/DataSeoulSubwayClient.java
+++ b/src/main/java/com/easyride/subway/client/dataseoul/DataSeoulSubwayClient.java
@@ -1,8 +1,7 @@
 package com.easyride.subway.client.dataseoul;
 
-import com.easyride.subway.client.dto.DataSeoulRealTimeSubwayPositionResponse;
+import com.easyride.subway.client.dto.DataSeoulRealTimeSubwayResponse;
 import com.easyride.subway.domain.StationLine;
-import com.easyride.subway.domain.Subways;
 import java.util.Map;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -35,12 +34,11 @@ public class DataSeoulSubwayClient {
                 .toUriString();
     }
 
-    public Subways fetchRealTimeSubwayPositions(StationLine stationLine) {
+    public DataSeoulRealTimeSubwayResponse fetchRealTimeSubwaysByLine(StationLine stationLine) {
         String stationLineName = DataSeoulStationLineMapper.asStationLineName(stationLine);
-        DataSeoulRealTimeSubwayPositionResponse response = restClient.get()
+        return restClient.get()
                 .uri(makeRealTimeSubwayPositionUri(stationLineName))
                 .exchange((req, res) -> responseConverter.convert(res));
-        return response.toSubways();
     }
 
     private String makeRealTimeSubwayPositionUri(String stationLineName) {

--- a/src/main/java/com/easyride/subway/client/dto/DataSeoulRealTimeSubwayResponse.java
+++ b/src/main/java/com/easyride/subway/client/dto/DataSeoulRealTimeSubwayResponse.java
@@ -13,19 +13,24 @@ import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
-public record DataSeoulRealTimeSubwayPositionResponse(
+public record DataSeoulRealTimeSubwayResponse(
         DataSeoulErrorResponse errorMessage,
         List<RealTimePosition> realtimePositionList
 ) {
 
     public Subways toSubways() {
-        List<Subway> subways = realtimePositionList.stream()
-                .map(position -> new Subway(position.subwayNumber,
-                        SubwayDirectionMapper.asDirection(position.direction, position.stationLineId.charAt(3)),
-                        toSubwayStation(position.stationId, position.stationName),
-                        toSubwayStation(position.endStationId, position.endStationName)))
-                .toList();
-        return new Subways(subways);
+        Subways subways = new Subways();
+        realtimePositionList.stream()
+                .map(this::toSubway)
+                .forEach(subways::add);
+        return subways;
+    }
+
+    private Subway toSubway(RealTimePosition position) {
+        return new Subway(position.subwayNumber,
+                SubwayDirectionMapper.asDirection(position.direction, position.stationLineId.charAt(3)),
+                toSubwayStation(position.stationId, position.stationName),
+                toSubwayStation(position.endStationId, position.endStationName));
     }
 
     private SubwayStation toSubwayStation(String id, String name) {

--- a/src/main/java/com/easyride/subway/client/dto/OdsayStationPathResponse.java
+++ b/src/main/java/com/easyride/subway/client/dto/OdsayStationPathResponse.java
@@ -1,0 +1,102 @@
+package com.easyride.subway.client.dto;
+
+import com.easyride.global.exception.EasyRideException;
+import com.easyride.subway.domain.Subway;
+import com.easyride.subway.domain.SubwayDirection;
+import com.easyride.subway.domain.SubwayPath;
+import com.easyride.subway.domain.SubwayStation;
+import com.easyride.subway.exception.SubwayErrorCode;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+public class OdsayStationPathResponse extends OdsayResponse {
+
+    private final SuccessDetail result;
+
+    public OdsayStationPathResponse(List<ErrorDetail> error, SuccessDetail result) {
+        super(error);
+        this.result = result;
+    }
+
+    public SubwayPath toSubwayPath(Subway subway) {
+        DriveInfoDetail driveInfo = result.driveInfoSet.driveInfo.get(0);
+        List<SubwayStation> stations = result.stationSet.stations.stream()
+                .map(detail -> toSubwayStation(detail, Integer.parseInt(driveInfo.stationLine)))
+                .toList();
+        return new SubwayPath(
+                subway,
+                SubwayDirectionMapper.asDirection(driveInfo.wayCode, driveInfo.stationLine),
+                stations);
+    }
+
+    private SubwayStation toSubwayStation(StationPathDetail stationPathDetail, int stationLine) {
+        return SubwayStation.of(stationPathDetail.passingStationId, stationPathDetail.passingStationName, stationLine);
+    }
+
+    private record SuccessDetail(
+            DriveInfoSet driveInfoSet,
+            StationSet stationSet
+    ) {
+    }
+
+    private record DriveInfoSet(
+            List<DriveInfoDetail> driveInfo
+    ) {
+    }
+
+    private record DriveInfoDetail(
+            String stationLine,
+            Integer stationCount,
+            String wayCode
+    ) {
+    }
+
+    private record StationSet(
+            List<StationPathDetail> stations
+    ) {
+    }
+
+    private record StationPathDetail(
+            @JsonAlias("endSID")
+            String passingStationId,
+            @JsonAlias("endName")
+            String passingStationName
+    ) {
+    }
+
+    @RequiredArgsConstructor
+    private enum SubwayDirectionMapper {
+
+        UP_MAPPER("1", SubwayDirection.UP),
+        DOWN_MAPPER("2", SubwayDirection.DOWN),
+        INNER_MAPPER("2", SubwayDirection.INNER),
+        OUTER_MAPPER("1", SubwayDirection.OUTER),
+        ;
+
+        private final String value;
+        private final SubwayDirection direction;
+
+        private static SubwayDirection asDirection(String value, String stationLine) {
+            if (stationLine.equals("2")) {
+                return asDirectionWhenSeoulMetro2Line(value);
+            }
+            return Arrays.stream(values())
+                    .filter(mapper -> mapper.value.equals(value))
+                    .findAny()
+                    .orElseThrow(() -> new EasyRideException(SubwayErrorCode.INVALID_DIRECTION))
+                    .direction;
+        }
+
+        private static SubwayDirection asDirectionWhenSeoulMetro2Line(String value) {
+            if (value.equals(INNER_MAPPER.value)) {
+                return INNER_MAPPER.direction;
+            }
+            if (value.equals(OUTER_MAPPER.value)) {
+                return OUTER_MAPPER.direction;
+            }
+            throw new EasyRideException(SubwayErrorCode.INVALID_DIRECTION);
+        }
+    }
+}

--- a/src/main/java/com/easyride/subway/client/dto/OdsayStationPathResponse.java
+++ b/src/main/java/com/easyride/subway/client/dto/OdsayStationPathResponse.java
@@ -3,8 +3,8 @@ package com.easyride.subway.client.dto;
 import com.easyride.global.exception.EasyRideException;
 import com.easyride.subway.domain.Subway;
 import com.easyride.subway.domain.SubwayDirection;
-import com.easyride.subway.domain.SubwayPath;
 import com.easyride.subway.domain.SubwayStation;
+import com.easyride.subway.domain.SubwayWithPath;
 import com.easyride.subway.exception.SubwayErrorCode;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import java.util.Arrays;
@@ -20,15 +20,17 @@ public class OdsayStationPathResponse extends OdsayResponse {
         this.result = result;
     }
 
-    public SubwayPath toSubwayPath(Subway subway) {
+    public SubwayDirection toSubwayDirection() {
         DriveInfoDetail driveInfo = result.driveInfoSet.driveInfo.get(0);
-        List<SubwayStation> stations = result.stationSet.stations.stream()
+        return DirectionMapper.asDirection(driveInfo.wayCode, driveInfo.stationLine);
+    }
+
+    public SubwayWithPath toSubwayPath(Subway subway) {
+        DriveInfoDetail driveInfo = result.driveInfoSet.driveInfo.get(0);
+        List<SubwayStation> path = result.stationSet.stations.stream()
                 .map(detail -> toSubwayStation(detail, Integer.parseInt(driveInfo.stationLine)))
                 .toList();
-        return new SubwayPath(
-                subway,
-                SubwayDirectionMapper.asDirection(driveInfo.wayCode, driveInfo.stationLine),
-                stations);
+        return new SubwayWithPath(subway, DirectionMapper.asDirection(driveInfo.wayCode, driveInfo.stationLine), path);
     }
 
     private SubwayStation toSubwayStation(StationPathDetail stationPathDetail, int stationLine) {
@@ -67,7 +69,7 @@ public class OdsayStationPathResponse extends OdsayResponse {
     }
 
     @RequiredArgsConstructor
-    private enum SubwayDirectionMapper {
+    private enum DirectionMapper {
 
         UP_MAPPER("1", SubwayDirection.UP),
         DOWN_MAPPER("2", SubwayDirection.DOWN),

--- a/src/main/java/com/easyride/subway/client/odsay/OdsaySubwayClient.java
+++ b/src/main/java/com/easyride/subway/client/odsay/OdsaySubwayClient.java
@@ -3,11 +3,6 @@ package com.easyride.subway.client.odsay;
 import com.easyride.subway.client.dto.OdsaySearchStationResponse;
 import com.easyride.subway.client.dto.OdsayStationInfoResponse;
 import com.easyride.subway.client.dto.OdsayStationPathResponse;
-import com.easyride.subway.domain.NearSubwayStations;
-import com.easyride.subway.domain.Subway;
-import com.easyride.subway.domain.SubwayPath;
-import com.easyride.subway.domain.SubwayStation;
-import com.easyride.subway.domain.SubwayStations;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -39,11 +34,10 @@ public class OdsaySubwayClient {
                 .toUriString();
     }
 
-    public SubwayStations searchStation(String stationName) {
-        OdsaySearchStationResponse response = restClient.get()
+    public OdsaySearchStationResponse searchStation(String stationName) {
+        return restClient.get()
                 .uri(makeSearchStationUri(stationName))
                 .exchange((req, res) -> responseConverter.convert(res, OdsaySearchStationResponse.class));
-        return response.toSubwayStations();
     }
 
     private String makeSearchStationUri(String stationName) {
@@ -55,11 +49,10 @@ public class OdsaySubwayClient {
                 .toUriString();
     }
 
-    public NearSubwayStations fetchStationInfo(String stationId) {
-        OdsayStationInfoResponse response = restClient.get()
+    public OdsayStationInfoResponse fetchStationInfo(String stationId) {
+        return restClient.get()
                 .uri(makeStationInfoUri(stationId))
                 .exchange((req, res) -> responseConverter.convert(res, OdsayStationInfoResponse.class));
-        return response.toNearSubwayStations();
     }
 
     private String makeStationInfoUri(String stationId) {
@@ -70,13 +63,10 @@ public class OdsaySubwayClient {
                 .toUriString();
     }
 
-    public SubwayPath fetchSubwayPath(Subway subway) {
-        SubwayStation startStation = subway.getNowStation();
-        SubwayStation endStation = subway.getEndStation();
-        OdsayStationPathResponse response = restClient.get()
-                .uri(makeSubwayPathUri(startStation.getId(), endStation.getId()))
+    public OdsayStationPathResponse fetchSubwayPath(String startStationId, String endStationId) {
+        return restClient.get()
+                .uri(makeSubwayPathUri(startStationId, endStationId))
                 .exchange((req, res) -> responseConverter.convert(res, OdsayStationPathResponse.class));
-        return response.toSubwayPath(subway);
     }
 
     private String makeSubwayPathUri(String startStationId, String endStationId) {

--- a/src/main/java/com/easyride/subway/client/odsay/OdsaySubwayClient.java
+++ b/src/main/java/com/easyride/subway/client/odsay/OdsaySubwayClient.java
@@ -2,7 +2,11 @@ package com.easyride.subway.client.odsay;
 
 import com.easyride.subway.client.dto.OdsaySearchStationResponse;
 import com.easyride.subway.client.dto.OdsayStationInfoResponse;
+import com.easyride.subway.client.dto.OdsayStationPathResponse;
 import com.easyride.subway.domain.NearSubwayStations;
+import com.easyride.subway.domain.Subway;
+import com.easyride.subway.domain.SubwayPath;
+import com.easyride.subway.domain.SubwayStation;
 import com.easyride.subway.domain.SubwayStations;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -15,7 +19,9 @@ public class OdsaySubwayClient {
 
     private static final String PATH_OF_SEARCH_STATION = "/searchStation";
     private static final String PATH_OF_FETCH_STATION_INFO = "/subwayStationInfo";
+    private static final String PATH_OF_FETCH_SUBWAY_PATH = "/subwayPath";
     private static final int STATION_CLASS_OF_SUBWAY = 2;
+    private static final int SEARCH_PATH_CONDITION_OF_MIN_EXCHANGE = 2;
 
     private final RestClient restClient;
     private final OdsayResponseConverter responseConverter;
@@ -60,6 +66,26 @@ public class OdsaySubwayClient {
         return UriComponentsBuilder.newInstance()
                 .path(PATH_OF_FETCH_STATION_INFO)
                 .queryParam("stationID", stationId)
+                .build(false)
+                .toUriString();
+    }
+
+    public SubwayPath fetchSubwayPath(Subway subway) {
+        SubwayStation startStation = subway.getNowStation();
+        SubwayStation endStation = subway.getEndStation();
+        OdsayStationPathResponse response = restClient.get()
+                .uri(makeSubwayPathUri(startStation.getId(), endStation.getId()))
+                .exchange((req, res) -> responseConverter.convert(res, OdsayStationPathResponse.class));
+        return response.toSubwayPath(subway);
+    }
+
+    private String makeSubwayPathUri(String startStationId, String endStationId) {
+        return UriComponentsBuilder.newInstance()
+                .path(PATH_OF_FETCH_SUBWAY_PATH)
+                .queryParam("CID", 1000)
+                .queryParam("SID", startStationId)
+                .queryParam("EID", endStationId)
+                .queryParam("Sopt", SEARCH_PATH_CONDITION_OF_MIN_EXCHANGE)
                 .build(false)
                 .toUriString();
     }

--- a/src/main/java/com/easyride/subway/client/sk/SkSubwayClient.java
+++ b/src/main/java/com/easyride/subway/client/sk/SkSubwayClient.java
@@ -1,8 +1,7 @@
 package com.easyride.subway.client.sk;
 
 import com.easyride.subway.client.dto.SkRealTimeCongestionResponse;
-import com.easyride.subway.domain.Subway;
-import com.easyride.subway.domain.SubwayCongestion;
+import com.easyride.subway.domain.StationLine;
 import java.util.Map;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
@@ -26,11 +25,10 @@ public class SkSubwayClient {
         this.responseConverter = SkResponseConverter.getInstance();
     }
 
-    public SubwayCongestion fetchCongestion(Subway subway) {
-        SkRealTimeCongestionResponse response = restClient.get()
-                .uri(makeRealTimeCongestionUri(subway.stationLine().getNumber(), subway.getId()))
+    public SkRealTimeCongestionResponse fetchCongestion(StationLine stationLine, String subwayId) {
+        return restClient.get()
+                .uri(makeRealTimeCongestionUri(stationLine.getNumber(), subwayId))
                 .exchange((req, res) -> responseConverter.convert(res));
-        return response.toSubwayCongestion(subway);
     }
 
     private String makeRealTimeCongestionUri(int subwayLine, String subwayId) {

--- a/src/main/java/com/easyride/subway/domain/Subway.java
+++ b/src/main/java/com/easyride/subway/domain/Subway.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-@EqualsAndHashCode(of = {"id", "direction", "nowStation", "endStation"}) // todo ?
+@EqualsAndHashCode(of = {"id", "direction", "nowStation", "endStation"})
 public class Subway {
 
     private final String id;
@@ -14,8 +14,8 @@ public class Subway {
     private final SubwayStation nowStation;
     private final SubwayStation endStation;
 
-    public boolean isSameDirection(SubwayDirection direction) {
-        return this.direction.isSame(direction);
+    public boolean isDifferentDirection(SubwayDirection direction) {
+        return this.direction.isDifferent(direction);
     }
 
     public StationLine stationLine() {

--- a/src/main/java/com/easyride/subway/domain/Subway.java
+++ b/src/main/java/com/easyride/subway/domain/Subway.java
@@ -18,25 +18,6 @@ public class Subway {
         return this.direction.isSame(direction);
     }
 
-    public boolean willPass(SubwayStation targetStation) {
-        if (targetStation.hasLine(StationLine.SEOUL_METRO_2)) {
-            if (endStation.getName().equals("성수종착")) {
-                return true;
-            }
-            // TODO 엣지 케이스 보충 필요
-        }
-        int target = Integer.parseInt(targetStation.getId());
-        int now = Integer.parseInt(nowStation.getId());
-        int end = Integer.parseInt(endStation.getId());
-        return Math.min(now, end) <= target && target < Math.max(now, end);
-    }
-
-    public int distanceFrom(SubwayStation targetStation) {
-        int target = Integer.parseInt(targetStation.getId());
-        int now = Integer.parseInt(nowStation.getId());
-        return Math.abs(target - now);
-    }
-
     public StationLine stationLine() {
         return this.nowStation.getLine();
     }

--- a/src/main/java/com/easyride/subway/domain/SubwayDirection.java
+++ b/src/main/java/com/easyride/subway/domain/SubwayDirection.java
@@ -1,8 +1,5 @@
 package com.easyride.subway.domain;
 
-import com.easyride.global.exception.EasyRideException;
-import com.easyride.subway.exception.SubwayErrorCode;
-
 public enum SubwayDirection {
 
     UP,
@@ -13,38 +10,5 @@ public enum SubwayDirection {
 
     public boolean isSame(SubwayDirection direction) {
         return this == direction;
-    }
-
-    public static SubwayDirection decideDirection(SubwayStation fromStation, SubwayStation toStation) {
-        int from = Integer.parseInt(fromStation.getId());
-        int to = Integer.parseInt(toStation.getId());
-        if (isSeoulMetro2Line(fromStation, toStation)) {
-            return decideInnerOuter(from, to);
-        }
-        return decideUpDown(from, to);
-    }
-
-    private static boolean isSeoulMetro2Line(SubwayStation fromStation, SubwayStation toStation) {
-        return fromStation.hasLine(StationLine.SEOUL_METRO_2) && toStation.hasLine(StationLine.SEOUL_METRO_2);
-    }
-
-    private static SubwayDirection decideInnerOuter(int from, int to) {
-        if (from < to) {
-            return INNER;
-        }
-        if (from > to) {
-            return OUTER;
-        }
-        throw new EasyRideException(SubwayErrorCode.INVALID_DIRECTION);
-    }
-
-    private static SubwayDirection decideUpDown(int from, int to) {
-        if (from > to) {
-            return UP;
-        }
-        if (from < to) {
-            return DOWN;
-        }
-        throw new EasyRideException(SubwayErrorCode.INVALID_DIRECTION);
     }
 }

--- a/src/main/java/com/easyride/subway/domain/SubwayDirection.java
+++ b/src/main/java/com/easyride/subway/domain/SubwayDirection.java
@@ -8,7 +8,7 @@ public enum SubwayDirection {
     OUTER,
     ;
 
-    public boolean isSame(SubwayDirection direction) {
-        return this == direction;
+    public boolean isDifferent(SubwayDirection direction) {
+        return this != direction;
     }
 }

--- a/src/main/java/com/easyride/subway/domain/SubwayPath.java
+++ b/src/main/java/com/easyride/subway/domain/SubwayPath.java
@@ -1,0 +1,35 @@
+package com.easyride.subway.domain;
+
+import com.easyride.global.exception.EasyRideException;
+import com.easyride.subway.exception.SubwayErrorCode;
+import java.util.List;
+import lombok.Getter;
+
+public class SubwayPath {
+
+    @Getter
+    private final Subway subway;
+    private final List<SubwayStation> passingStations;
+
+    public SubwayPath(Subway subway, SubwayDirection direction, List<SubwayStation> passingStations) {
+        this.subway = new Subway(subway.getId(), direction, subway.getNowStation(), subway.getEndStation());
+        this.passingStations = passingStations;
+    }
+
+    public boolean willPass(SubwayStation targetStation) {
+        // TODO: 현재 - 최단 경로를 기준으로 가져옴. 2호선의 경우 더 긴 경로를 가져올 수 있으므로 추후 데이터 DB 관리 또는 아래 로직 예정
+        // TODO: 2호선이면서 종착역이 성수이면 무조건 true 반환하도록
+        return passingStations.contains(targetStation);
+    }
+
+    public int distanceFrom(SubwayStation targetStation) {
+        if (!willPass(targetStation)) {
+            throw new EasyRideException(SubwayErrorCode.CANNOT_PASS_THAT_SUBWAY);
+        }
+        return passingStations.indexOf(targetStation) + 1;
+    }
+
+    public SubwayDirection getDirection() {
+        return subway.getDirection();
+    }
+}

--- a/src/main/java/com/easyride/subway/domain/SubwayStation.java
+++ b/src/main/java/com/easyride/subway/domain/SubwayStation.java
@@ -19,7 +19,8 @@ public class SubwayStation {
         return new SubwayStation(id, name, line);
     }
 
-    public boolean hasLine(StationLine stationLine) {
+    public boolean hasLine(int stationLineNumber) {
+        StationLine stationLine = StationLine.asStationLine(stationLineNumber);
         return line.isSame(stationLine);
     }
 }

--- a/src/main/java/com/easyride/subway/domain/SubwayStations.java
+++ b/src/main/java/com/easyride/subway/domain/SubwayStations.java
@@ -3,27 +3,22 @@ package com.easyride.subway.domain;
 import com.easyride.global.exception.EasyRideException;
 import com.easyride.subway.exception.SubwayErrorCode;
 import java.util.List;
+import java.util.function.Predicate;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 public class SubwayStations {
 
     private final List<SubwayStation> stations;
 
-    public SubwayStations(List<SubwayStation> stations) {
-        validate(stations);
-        this.stations = stations;
+    public boolean isEmpty() {
+        return this.stations.isEmpty();
     }
 
-    private void validate(List<SubwayStation> stations) {
-        if (stations.isEmpty()) {
-            throw new EasyRideException(SubwayErrorCode.INVALID_STATION);
-        }
-    }
-
-    public SubwayStation findStationByStationLine(int stationLineNumber) {
-        StationLine stationLine = StationLine.asStationLine(stationLineNumber);
+    public SubwayStation filter(Predicate<SubwayStation> condition, SubwayErrorCode errorCodeIfNotExist) {
         return stations.stream()
-                .filter(station -> station.hasLine(stationLine))
+                .filter(condition)
                 .findAny()
-                .orElseThrow(() -> new EasyRideException(SubwayErrorCode.INVALID_STATION));
+                .orElseThrow(() -> new EasyRideException(errorCodeIfNotExist));
     }
 }

--- a/src/main/java/com/easyride/subway/domain/SubwayWithPath.java
+++ b/src/main/java/com/easyride/subway/domain/SubwayWithPath.java
@@ -5,31 +5,27 @@ import com.easyride.subway.exception.SubwayErrorCode;
 import java.util.List;
 import lombok.Getter;
 
-public class SubwayPath {
+public class SubwayWithPath {
 
     @Getter
     private final Subway subway;
-    private final List<SubwayStation> passingStations;
+    private final List<SubwayStation> path;
 
-    public SubwayPath(Subway subway, SubwayDirection direction, List<SubwayStation> passingStations) {
+    public SubwayWithPath(Subway subway, SubwayDirection direction, List<SubwayStation> path) {
         this.subway = new Subway(subway.getId(), direction, subway.getNowStation(), subway.getEndStation());
-        this.passingStations = passingStations;
+        this.path = path;
     }
 
     public boolean willPass(SubwayStation targetStation) {
         // TODO: 현재 - 최단 경로를 기준으로 가져옴. 2호선의 경우 더 긴 경로를 가져올 수 있으므로 추후 데이터 DB 관리 또는 아래 로직 예정
         // TODO: 2호선이면서 종착역이 성수이면 무조건 true 반환하도록
-        return passingStations.contains(targetStation);
+        return path.contains(targetStation);
     }
 
     public int distanceFrom(SubwayStation targetStation) {
         if (!willPass(targetStation)) {
             throw new EasyRideException(SubwayErrorCode.CANNOT_PASS_THAT_SUBWAY);
         }
-        return passingStations.indexOf(targetStation) + 1;
-    }
-
-    public SubwayDirection getDirection() {
-        return subway.getDirection();
+        return path.indexOf(targetStation) + 1;
     }
 }

--- a/src/main/java/com/easyride/subway/domain/Subways.java
+++ b/src/main/java/com/easyride/subway/domain/Subways.java
@@ -1,15 +1,25 @@
 package com.easyride.subway.domain;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
-@RequiredArgsConstructor
 public class Subways {
 
-    private final List<Subway> subways;
+    private final List<Subway> subways = new ArrayList<>();
 
-    public List<Subway> getSubways() {
-        return Collections.unmodifiableList(subways);
+    public void add(Subway subway) {
+        this.subways.add(subway);
+    }
+
+    public void deleteIf(Predicate<Subway> condition) {
+        this.subways.removeIf(condition);
+    }
+
+    public <T> List<T> mapAll(Function<Subway, T> mapper) {
+        return this.subways.stream()
+                .map(mapper)
+                .toList();
     }
 }

--- a/src/main/java/com/easyride/subway/domain/Subways.java
+++ b/src/main/java/com/easyride/subway/domain/Subways.java
@@ -1,9 +1,6 @@
 package com.easyride.subway.domain;
 
-import com.easyride.global.exception.EasyRideException;
-import com.easyride.subway.exception.SubwayErrorCode;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
@@ -11,15 +8,6 @@ import lombok.RequiredArgsConstructor;
 public class Subways {
 
     private final List<Subway> subways;
-
-    public Subway findApproachingSubway(SubwayStation targetStation, SubwayStation nextStation) {
-        SubwayDirection direction = SubwayDirection.decideDirection(targetStation, nextStation);
-        return subways.stream()
-                .filter(subway -> subway.isSameDirection(direction))
-                .filter(subway -> subway.willPass(targetStation))
-                .min(Comparator.comparingInt(subway -> subway.distanceFrom(targetStation)))
-                .orElseThrow(() -> new EasyRideException(SubwayErrorCode.NO_APPROACHING_SUBWAY));
-    }
 
     public List<Subway> getSubways() {
         return Collections.unmodifiableList(subways);

--- a/src/main/java/com/easyride/subway/exception/SubwayErrorCode.java
+++ b/src/main/java/com/easyride/subway/exception/SubwayErrorCode.java
@@ -17,6 +17,7 @@ public enum SubwayErrorCode implements ErrorCode {
     INVALID_DIRECTION(HttpStatus.BAD_REQUEST, "유효하지 않은 방향입니다."),
     DATA_SEOUL_INVALID_STATION_LINE_NAME(HttpStatus.BAD_REQUEST, "유효하지 않은 지하철역 호선명입니다."),
     NO_APPROACHING_SUBWAY(HttpStatus.BAD_REQUEST, "다가올 지하철이 없습니다."),
+    CANNOT_PASS_THAT_SUBWAY(HttpStatus.BAD_REQUEST, "해당 위치를 지나지 않는 지하철입니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/easyride/subway/service/SubwayClientProcessor.java
+++ b/src/main/java/com/easyride/subway/service/SubwayClientProcessor.java
@@ -1,0 +1,61 @@
+package com.easyride.subway.service;
+
+import com.easyride.subway.client.dataseoul.DataSeoulSubwayClient;
+import com.easyride.subway.client.dto.DataSeoulRealTimeSubwayResponse;
+import com.easyride.subway.client.dto.OdsaySearchStationResponse;
+import com.easyride.subway.client.dto.OdsayStationInfoResponse;
+import com.easyride.subway.client.dto.OdsayStationPathResponse;
+import com.easyride.subway.client.dto.SkRealTimeCongestionResponse;
+import com.easyride.subway.client.odsay.OdsaySubwayClient;
+import com.easyride.subway.client.sk.SkSubwayClient;
+import com.easyride.subway.domain.NearSubwayStations;
+import com.easyride.subway.domain.Subway;
+import com.easyride.subway.domain.SubwayCongestion;
+import com.easyride.subway.domain.SubwayDirection;
+import com.easyride.subway.domain.SubwayStation;
+import com.easyride.subway.domain.SubwayStations;
+import com.easyride.subway.domain.SubwayWithPath;
+import com.easyride.subway.domain.Subways;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class SubwayClientProcessor {
+
+    private final OdsaySubwayClient odsaySubwayClient;
+    private final DataSeoulSubwayClient dataSeoulSubwayClient;
+    private final SkSubwayClient skSubwayClient;
+
+    public SubwayStations searchStation(String stationName) {
+        OdsaySearchStationResponse response = odsaySubwayClient.searchStation(stationName);
+        return response.toSubwayStations();
+    }
+
+    public NearSubwayStations fetchNearStations(SubwayStation station) {
+        OdsayStationInfoResponse response = odsaySubwayClient.fetchStationInfo(station.getId());
+        return response.toNearSubwayStations();
+    }
+
+    public SubwayDirection fetchSubwayDirection(SubwayStation startStation, SubwayStation endStation) {
+        OdsayStationPathResponse response = odsaySubwayClient.fetchSubwayPath(startStation.getId(), endStation.getId());
+        return response.toSubwayDirection();
+    }
+
+    public Subways fetchRealTimeSubways(SubwayStation station) {
+        DataSeoulRealTimeSubwayResponse response = dataSeoulSubwayClient.fetchRealTimeSubwaysByLine(station.getLine());
+        return response.toSubways();
+    }
+
+    public SubwayWithPath fetchSubwayPath(Subway subway) {
+        OdsayStationPathResponse response = odsaySubwayClient.fetchSubwayPath(
+                subway.getNowStation().getId(),
+                subway.getEndStation().getId());
+        return response.toSubwayPath(subway);
+    }
+
+    public SubwayCongestion fetchSubwayCongestion(Subway subway) {
+        SkRealTimeCongestionResponse response = skSubwayClient.fetchCongestion(subway.stationLine(), subway.getId());
+        return response.toSubwayCongestion(subway);
+    }
+}

--- a/src/main/java/com/easyride/subway/service/SubwayService.java
+++ b/src/main/java/com/easyride/subway/service/SubwayService.java
@@ -1,16 +1,22 @@
 package com.easyride.subway.service;
 
+import com.easyride.global.exception.EasyRideException;
 import com.easyride.subway.client.dataseoul.DataSeoulSubwayClient;
 import com.easyride.subway.client.odsay.OdsaySubwayClient;
 import com.easyride.subway.client.sk.SkSubwayClient;
 import com.easyride.subway.domain.NearSubwayStations;
 import com.easyride.subway.domain.Subway;
 import com.easyride.subway.domain.SubwayCongestion;
+import com.easyride.subway.domain.SubwayDirection;
+import com.easyride.subway.domain.SubwayPath;
 import com.easyride.subway.domain.SubwayStation;
 import com.easyride.subway.domain.SubwayStations;
 import com.easyride.subway.domain.Subways;
+import com.easyride.subway.exception.SubwayErrorCode;
 import com.easyride.subway.service.dto.NearSubwayStationsResponse;
 import com.easyride.subway.service.dto.SubwayCarCongestionsResponse;
+import java.util.Comparator;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -30,8 +36,25 @@ public class SubwayService {
     }
 
     public SubwayCarCongestionsResponse findSubwayCongestion(SubwayStation targetStation, SubwayStation nextStation) {
+        // TODO 너무 많은 API 호출량
+        SubwayPath subwayPathOfTarget = odsaySubwayClient.fetchSubwayPath(
+                new Subway(null, null, targetStation, nextStation)); // TODO client 역할 줄이도록 리팩터링
+        SubwayDirection direction = subwayPathOfTarget.getDirection();
+
+        // 같은 방향의 전철만 거르기
         Subways subways = dataSeoulSubwayClient.fetchRealTimeSubwayPositions(targetStation.getLine());
-        Subway subway = subways.findApproachingSubway(targetStation, nextStation);
+        List<Subway> subwaysWithSameDirection = subways.getSubways().stream()
+                .filter(subway -> subway.isSameDirection(direction))
+                .toList();
+
+        List<SubwayPath> subwayPaths = subwaysWithSameDirection.stream()
+                .map(odsaySubwayClient::fetchSubwayPath)
+                .toList();
+        Subway subway = subwayPaths.stream()
+                .filter(subwayPath -> subwayPath.willPass(targetStation))
+                .min(Comparator.comparingInt(subwayPath -> subwayPath.distanceFrom(targetStation)))
+                .orElseThrow(() -> new EasyRideException(SubwayErrorCode.NO_APPROACHING_SUBWAY))
+                .getSubway();
         SubwayCongestion subwayCongestion = skSubwayClient.fetchCongestion(subway);
         return new SubwayCarCongestionsResponse(targetStation, nextStation, subwayCongestion);
     }

--- a/src/main/java/com/easyride/subway/service/SubwayService.java
+++ b/src/main/java/com/easyride/subway/service/SubwayService.java
@@ -1,14 +1,10 @@
 package com.easyride.subway.service;
 
 import com.easyride.global.exception.EasyRideException;
-import com.easyride.subway.client.dataseoul.DataSeoulSubwayClient;
-import com.easyride.subway.client.odsay.OdsaySubwayClient;
-import com.easyride.subway.client.sk.SkSubwayClient;
 import com.easyride.subway.domain.NearSubwayStations;
 import com.easyride.subway.domain.Subway;
 import com.easyride.subway.domain.SubwayCongestion;
 import com.easyride.subway.domain.SubwayDirection;
-import com.easyride.subway.domain.SubwayPath;
 import com.easyride.subway.domain.SubwayStation;
 import com.easyride.subway.domain.SubwayStations;
 import com.easyride.subway.domain.Subways;
@@ -16,7 +12,6 @@ import com.easyride.subway.exception.SubwayErrorCode;
 import com.easyride.subway.service.dto.NearSubwayStationsResponse;
 import com.easyride.subway.service.dto.SubwayCarCongestionsResponse;
 import java.util.Comparator;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,38 +19,40 @@ import org.springframework.stereotype.Service;
 @Service
 public class SubwayService {
 
-    private final OdsaySubwayClient odsaySubwayClient;
-    private final DataSeoulSubwayClient dataSeoulSubwayClient;
-    private final SkSubwayClient skSubwayClient;
+    private final SubwayClientProcessor clientProcessor;
 
     public NearSubwayStationsResponse findNearSubwayStations(String stationName, int stationLine) {
-        SubwayStations searchStations = odsaySubwayClient.searchStation(stationName);
-        SubwayStation searchStation = searchStations.findStationByStationLine(stationLine);
-        NearSubwayStations nearStations = odsaySubwayClient.fetchStationInfo(searchStation.getId());
+        SubwayStations candidateStations = clientProcessor.searchStation(stationName);
+        validateIsEmpty(candidateStations);
+        SubwayStation targetStation = candidateStations.filter(
+                station -> station.hasLine(stationLine),
+                SubwayErrorCode.INVALID_STATION);
+        NearSubwayStations nearStations = clientProcessor.fetchNearStations(targetStation);
         return new NearSubwayStationsResponse(nearStations);
+    }
+
+    private void validateIsEmpty(SubwayStations stations) {
+        if (stations.isEmpty()) {
+            throw new EasyRideException(SubwayErrorCode.INVALID_STATION);
+        }
     }
 
     public SubwayCarCongestionsResponse findSubwayCongestion(SubwayStation targetStation, SubwayStation nextStation) {
         // TODO 너무 많은 API 호출량
-        SubwayPath subwayPathOfTarget = odsaySubwayClient.fetchSubwayPath(
-                new Subway(null, null, targetStation, nextStation)); // TODO client 역할 줄이도록 리팩터링
-        SubwayDirection direction = subwayPathOfTarget.getDirection();
+        SubwayDirection direction = clientProcessor.fetchSubwayDirection(targetStation, nextStation);
+        Subways candidateSubways = clientProcessor.fetchRealTimeSubways(targetStation);
+        candidateSubways.deleteIf(subway -> subway.isDifferentDirection(direction));
+        Subway targetSubway = fetchTargetSubway(targetStation, candidateSubways);
+        SubwayCongestion subwayCongestion = clientProcessor.fetchSubwayCongestion(targetSubway);
+        return new SubwayCarCongestionsResponse(targetStation, nextStation, subwayCongestion);
+    }
 
-        // 같은 방향의 전철만 거르기
-        Subways subways = dataSeoulSubwayClient.fetchRealTimeSubwayPositions(targetStation.getLine());
-        List<Subway> subwaysWithSameDirection = subways.getSubways().stream()
-                .filter(subway -> subway.isSameDirection(direction))
-                .toList();
-
-        List<SubwayPath> subwayPaths = subwaysWithSameDirection.stream()
-                .map(odsaySubwayClient::fetchSubwayPath)
-                .toList();
-        Subway subway = subwayPaths.stream()
-                .filter(subwayPath -> subwayPath.willPass(targetStation))
-                .min(Comparator.comparingInt(subwayPath -> subwayPath.distanceFrom(targetStation)))
+    private Subway fetchTargetSubway(SubwayStation targetStation, Subways candidateSubways) {
+        return candidateSubways.mapAll(clientProcessor::fetchSubwayPath)
+                .stream()
+                .filter(subwayWithPath -> subwayWithPath.willPass(targetStation))
+                .min(Comparator.comparingInt(subwayWithPath -> subwayWithPath.distanceFrom(targetStation)))
                 .orElseThrow(() -> new EasyRideException(SubwayErrorCode.NO_APPROACHING_SUBWAY))
                 .getSubway();
-        SubwayCongestion subwayCongestion = skSubwayClient.fetchCongestion(subway);
-        return new SubwayCarCongestionsResponse(targetStation, nextStation, subwayCongestion);
     }
 }

--- a/src/main/java/com/easyride/subway/service/dto/SubwayStationDetail.java
+++ b/src/main/java/com/easyride/subway/service/dto/SubwayStationDetail.java
@@ -1,15 +1,14 @@
 package com.easyride.subway.service.dto;
 
-import com.easyride.subway.domain.StationLine;
 import com.easyride.subway.domain.SubwayStation;
 
 public record SubwayStationDetail(
         String id,
         String name,
-        StationLine line // TODO enum 값 확인
+        int line
 ) {
 
     public SubwayStationDetail(SubwayStation station) {
-        this(station.getId(), station.getName(), station.getLine());
+        this(station.getId(), station.getName(), station.getLine().getNumber());
     }
 }

--- a/src/test/java/com/easyride/subway/client/dataseoul/DataSeoulSubwayClientTest.java
+++ b/src/test/java/com/easyride/subway/client/dataseoul/DataSeoulSubwayClientTest.java
@@ -1,18 +1,12 @@
 package com.easyride.subway.client.dataseoul;
 
-import static com.easyride.subway.fixture.SubwayFixture.POSITION_2344;
-import static com.easyride.subway.fixture.SubwayFixture.POSITION_2373;
-import static com.easyride.subway.fixture.SubwayFixture.POSITION_2389;
-import static com.easyride.subway.fixture.SubwayFixture.POSITION_2390;
-import static com.easyride.subway.fixture.SubwayFixture.POSITION_2413;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.easyride.global.config.BaseRestClientTest;
 import com.easyride.global.exception.EasyRideException;
 import com.easyride.subway.domain.StationLine;
-import com.easyride.subway.domain.Subways;
 import com.easyride.subway.helper.DataSeoulUriGenerator;
 import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,19 +33,15 @@ class DataSeoulSubwayClientTest extends BaseRestClientTest {
     }
 
     @Test
-    void 지하철역_호선_이름으로_실시간_지하철_위치정보조회에_성공하면_도메인을_반환한다() throws IOException {
+    void 지하철역_호선_이름으로_실시간_지하철_위치정보조회에_성공한다() throws IOException {
         // given
         String requestUri = uriGenerator.makeRealTimeTrainPositionUri("2호선");
         String responseBody = readResourceFile("dataseoul/success/real-time-train-position.json");
         configure200MockServer(requestUri, responseBody);
 
-        // when
-        Subways subways = subwayClient.fetchRealTimeSubwayPositions(StationLine.SEOUL_METRO_2);
-
-        // then
+        // when & then
         assertAll(
-                () -> assertThat(subways.getSubways())
-                        .containsExactly(POSITION_2390, POSITION_2413, POSITION_2373, POSITION_2344, POSITION_2389),
+                () -> assertDoesNotThrow(() -> subwayClient.fetchRealTimeSubwaysByLine(StationLine.SEOUL_METRO_2)),
                 () -> mockServer.verify()
         );
     }
@@ -65,7 +55,7 @@ class DataSeoulSubwayClientTest extends BaseRestClientTest {
 
         // when & then
         assertAll(
-                () -> assertThatThrownBy(() -> subwayClient.fetchRealTimeSubwayPositions(StationLine.SEOUL_METRO_2))
+                () -> assertThatThrownBy(() -> subwayClient.fetchRealTimeSubwaysByLine(StationLine.SEOUL_METRO_2))
                         .isInstanceOf(EasyRideException.class)
                         .hasMessage("서울시 공공데이터 API 호출 과정에서 예외가 발생했습니다."),
                 () -> mockServer.verify()
@@ -81,7 +71,7 @@ class DataSeoulSubwayClientTest extends BaseRestClientTest {
 
         // when & then
         assertAll(
-                () -> assertThatThrownBy(() -> subwayClient.fetchRealTimeSubwayPositions(StationLine.SEOUL_METRO_2))
+                () -> assertThatThrownBy(() -> subwayClient.fetchRealTimeSubwaysByLine(StationLine.SEOUL_METRO_2))
                         .isInstanceOf(EasyRideException.class)
                         .hasMessage("해당 호선에서 현재 운행 중인 지하철이 없습니다."),
                 () -> mockServer.verify()

--- a/src/test/java/com/easyride/subway/client/odsay/OdsaySubwayClientTest.java
+++ b/src/test/java/com/easyride/subway/client/odsay/OdsaySubwayClientTest.java
@@ -1,14 +1,11 @@
 package com.easyride.subway.client.odsay;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.easyride.global.config.BaseRestClientTest;
 import com.easyride.global.exception.EasyRideException;
-import com.easyride.subway.domain.NearSubwayStations;
-import com.easyride.subway.domain.SubwayStations;
 import com.easyride.subway.helper.OdsayUriGenerator;
 import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,37 +32,29 @@ class OdsaySubwayClientTest extends BaseRestClientTest {
     }
 
     @Test
-    void 지하철역_이름으로_지하철역_상세정보조회에_성공하면_도메인을_반환한다() throws IOException {
+    void 지하철역_이름으로_지하철역_상세정보조회에_성공한다() throws IOException {
         // given
         String requestUri = uriGenerator.makeSearchStationUri("오이도");
         String responseBody = readResourceFile("odsay/success/search-station.json");
         configure200MockServer(requestUri, responseBody);
 
-        // when
-        SubwayStations subwayStations = subwayClient.searchStation("오이도");
-
-        // then
+        // when & then
         assertAll(
-                () -> assertDoesNotThrow(() -> subwayStations.findStationByStationLine(4)),
-                () -> assertDoesNotThrow(() -> subwayStations.findStationByStationLine(116)),
+                () -> assertDoesNotThrow(() -> subwayClient.searchStation("오이도")),
                 () -> mockServer.verify()
         );
     }
 
     @Test
-    void 지하철역_ID로_양옆_지하철역_세부정보조회에_성공하면_도메인을_반환한다() throws IOException {
+    void 지하철역_ID로_양옆_지하철역_세부정보조회에_성공한다() throws IOException {
         // given
         String requestUri = uriGenerator.makeStationInfoUri("456"); // 오이도
         String responseBody = readResourceFile("odsay/success/station-info.json");
         configure200MockServer(requestUri, responseBody);
 
-        // when
-        NearSubwayStations nearStations = subwayClient.fetchStationInfo("456");
-
-        // then
+        // when & then
         assertAll(
-                () -> assertThat(nearStations.getStations()).hasSize(1),
-                () -> assertThat(nearStations.getStations().get(0).getName()).isEqualTo("정왕"),
+                () -> assertDoesNotThrow(() -> subwayClient.fetchStationInfo("456")),
                 () -> mockServer.verify()
         );
     }

--- a/src/test/java/com/easyride/subway/client/sk/SkSubwayClientTest.java
+++ b/src/test/java/com/easyride/subway/client/sk/SkSubwayClientTest.java
@@ -1,17 +1,12 @@
 package com.easyride.subway.client.sk;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.easyride.global.config.BaseRestClientTest;
 import com.easyride.global.exception.EasyRideException;
 import com.easyride.subway.domain.StationLine;
-import com.easyride.subway.domain.Subway;
-import com.easyride.subway.domain.SubwayCarCongestion;
-import com.easyride.subway.domain.SubwayCongestion;
-import com.easyride.subway.domain.SubwayDirection;
-import com.easyride.subway.domain.SubwayStation;
 import com.easyride.subway.helper.SkUriGenerator;
 import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,24 +33,15 @@ public class SkSubwayClientTest extends BaseRestClientTest {
     }
 
     @Test
-    void 지하철역_호선과_열차번호로_실시간_지하철_혼잡도_조회에_성공하면_도메인을_반환한다() throws IOException {
+    void 지하철역_호선과_열차번호로_실시간_지하철_혼잡도_조회에_성공한다() throws IOException {
         // given
         String requestUri = uriGenerator.makeRealTimeCongestionUri(2, "2413");
         String responseBody = readResourceFile("sk/success/real-time-congestion.json");
         configure200MockServer(requestUri, responseBody);
 
-        // when
-        Subway subway = new Subway("2413", SubwayDirection.OUTER, SubwayStation.of("211", "한양대", 2), null);
-        SubwayCongestion subwayCongestion = subwayClient.fetchCongestion(subway);
-
-        // then
+        // when & then
         assertAll(
-                () -> assertThat(subwayCongestion.getSubway().stationLine()).isEqualTo(StationLine.SEOUL_METRO_2),
-                () -> assertThat(subwayCongestion.getSubway().getId()).isEqualTo("2413"),
-                () -> assertThat(subwayCongestion.getSubwayCongestion()).isEqualTo(57),
-                () -> assertThat(subwayCongestion.getCarCongestions())
-                        .map(SubwayCarCongestion::getCongestion)
-                        .containsExactly(46, 38, 46, 31, 67, 68, 66, 78, 69, 63),
+                () -> assertDoesNotThrow(() -> subwayClient.fetchCongestion(StationLine.SEOUL_METRO_2, "2413")),
                 () -> mockServer.verify()
         );
     }
@@ -68,9 +54,8 @@ public class SkSubwayClientTest extends BaseRestClientTest {
         configure403MockServer(requestUri, responseBody);
 
         // when & then
-        Subway subway = new Subway("2413", SubwayDirection.OUTER, SubwayStation.of("211", "한양대", 2), null);
         assertAll(
-                () -> assertThatThrownBy(() -> subwayClient.fetchCongestion(subway))
+                () -> assertThatThrownBy(() -> subwayClient.fetchCongestion(StationLine.SEOUL_METRO_2, "2413"))
                         .isInstanceOf(EasyRideException.class)
                         .hasMessage("SK Open API 호출 과정에서 예외가 발생했습니다."),
                 () -> mockServer.verify()
@@ -85,9 +70,8 @@ public class SkSubwayClientTest extends BaseRestClientTest {
         configure400MockServer(requestUri, responseBody);
 
         // when & then
-        Subway subway = new Subway("2413", SubwayDirection.OUTER, SubwayStation.of("132", "시청", 1), null);
         assertAll(
-                () -> assertThatThrownBy(() -> subwayClient.fetchCongestion(subway))
+                () -> assertThatThrownBy(() -> subwayClient.fetchCongestion(StationLine.SEOUL_METRO_1, "2413"))
                         .isInstanceOf(EasyRideException.class)
                         .hasMessage("SK Open API 호출 과정에서 예외가 발생했습니다."),
                 () -> mockServer.verify()

--- a/src/test/java/com/easyride/subway/fixture/SubwayFixture.java
+++ b/src/test/java/com/easyride/subway/fixture/SubwayFixture.java
@@ -6,28 +6,33 @@ import com.easyride.subway.domain.SubwayStation;
 
 public class SubwayFixture {
 
-    public static final Subway POSITION_2390 = new Subway("2390",
+    public static final Subway SUBWAY_2390 = new Subway("2390",
             SubwayDirection.INNER,
             SubwayStation.of("215", "잠실나루", 2),
             SubwayStation.of("211", "성수종착", 2));
 
-    public static final Subway POSITION_2413 = new Subway("2413",
+    public static final Subway SUBWAY_2413 = new Subway("2413",
             SubwayDirection.OUTER,
             SubwayStation.of("209", "한양대", 2),
             SubwayStation.of("211", "성수종착", 2));
 
-    public static final Subway POSITION_2373 = new Subway("2373",
+    public static final Subway SUBWAY_2373 = new Subway("2373",
             SubwayDirection.OUTER,
             SubwayStation.of("217", "잠실새내", 2),
             SubwayStation.of("211", "성수종착", 2));
 
-    public static final Subway POSITION_2344 = new Subway("2344",
+    public static final Subway SUBWAY_2344 = new Subway("2344",
             SubwayDirection.INNER,
             SubwayStation.of("209", "한양대", 2),
             SubwayStation.of("211", "성수종착", 2));
 
-    public static final Subway POSITION_2389 = new Subway("2389",
+    public static final Subway SUBWAY_2389 = new Subway("2389",
             SubwayDirection.OUTER,
             SubwayStation.of("230", "신림", 2),
             SubwayStation.of("211", "성수종착", 2));
+
+    public static final Subway SUBWAY_2490 = new Subway("2490",
+            SubwayDirection.OUTER,
+            SubwayStation.of("228", "서울대입구", 2),
+            SubwayStation.of("234", "신도림", 2));
 }

--- a/src/test/java/com/easyride/subway/service/SubwayServiceTest.java
+++ b/src/test/java/com/easyride/subway/service/SubwayServiceTest.java
@@ -112,7 +112,7 @@ class SubwayServiceTest { // TODO ServiceTest 생성
 
         // then
         assertAll(
-                () -> assertThat(response.station().line().getNumber()).isEqualTo(2),
+                () -> assertThat(response.station().line()).isEqualTo(2),
                 () -> assertThat(response.station().name()).isEqualTo("봉천"),
                 () -> assertThat(response.nextStation().name()).isEqualTo("신림"),
                 () -> assertThat(response.carCongestions())

--- a/src/test/java/com/easyride/subway/service/SubwayServiceTest.java
+++ b/src/test/java/com/easyride/subway/service/SubwayServiceTest.java
@@ -1,67 +1,57 @@
 package com.easyride.subway.service;
 
-import static com.easyride.subway.fixture.SubwayFixture.POSITION_2344;
-import static com.easyride.subway.fixture.SubwayFixture.POSITION_2373;
-import static com.easyride.subway.fixture.SubwayFixture.POSITION_2389;
-import static com.easyride.subway.fixture.SubwayFixture.POSITION_2390;
-import static com.easyride.subway.fixture.SubwayFixture.POSITION_2413;
+import static com.easyride.subway.fixture.SubwayFixture.SUBWAY_2344;
+import static com.easyride.subway.fixture.SubwayFixture.SUBWAY_2373;
+import static com.easyride.subway.fixture.SubwayFixture.SUBWAY_2389;
+import static com.easyride.subway.fixture.SubwayFixture.SUBWAY_2390;
+import static com.easyride.subway.fixture.SubwayFixture.SUBWAY_2413;
+import static com.easyride.subway.fixture.SubwayFixture.SUBWAY_2490;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 
-import com.easyride.subway.client.dataseoul.DataSeoulSubwayClient;
-import com.easyride.subway.client.odsay.OdsaySubwayClient;
-import com.easyride.subway.client.sk.SkSubwayClient;
 import com.easyride.subway.domain.NearSubwayStations;
-import com.easyride.subway.domain.StationLine;
 import com.easyride.subway.domain.Subway;
 import com.easyride.subway.domain.SubwayCongestion;
 import com.easyride.subway.domain.SubwayDirection;
-import com.easyride.subway.domain.SubwayPath;
 import com.easyride.subway.domain.SubwayStation;
 import com.easyride.subway.domain.SubwayStations;
+import com.easyride.subway.domain.SubwayWithPath;
 import com.easyride.subway.domain.Subways;
 import com.easyride.subway.service.dto.NearSubwayStationsResponse;
 import com.easyride.subway.service.dto.SubwayCarCongestionDetail;
 import com.easyride.subway.service.dto.SubwayCarCongestionsResponse;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class SubwayServiceTest { // TODO ServiceTest 생성
+class SubwayServiceTest {
 
     SubwayService subwayService;
 
     @Mock
-    OdsaySubwayClient odsaySubwayClient;
-
-    @Mock
-    DataSeoulSubwayClient dataSeoulSubwayClient;
-
-    @Mock
-    SkSubwayClient skSubwayClient;
+    SubwayClientProcessor clientProcessor;
 
     @BeforeEach
     void setUp() {
-        subwayService = new SubwayService(odsaySubwayClient, dataSeoulSubwayClient, skSubwayClient);
+        subwayService = new SubwayService(clientProcessor);
     }
 
     @Test
     void 호선과_이름을_기반으로_양옆의_지하철역을_조회한다() {
         // given
-        given(odsaySubwayClient.searchStation("봉천"))
+        given(clientProcessor.searchStation(anyString()))
                 .willReturn(new SubwayStations(List.of(SubwayStation.of("229", "봉천", 2))));
 
         NearSubwayStations nearSubwayStations = new NearSubwayStations();
         nearSubwayStations.addStations(List.of(SubwayStation.of("228", "서울대입구", 2)));
         nearSubwayStations.addStations(List.of(SubwayStation.of("230", "신림", 2)));
-        given(odsaySubwayClient.fetchStationInfo("229"))
+        given(clientProcessor.fetchNearStations(any(SubwayStation.class)))
                 .willReturn(nearSubwayStations);
 
         // when
@@ -78,12 +68,12 @@ class SubwayServiceTest { // TODO ServiceTest 생성
     @Test
     void 호선과_이름을_기반으로_양옆의_지하철역을_조회할_때_종점일_경우() {
         // given
-        given(odsaySubwayClient.searchStation(anyString()))
+        given(clientProcessor.searchStation(anyString()))
                 .willReturn(new SubwayStations(List.of(SubwayStation.of("456", "오이도", 4))));
 
         NearSubwayStations nearSubwayStations = new NearSubwayStations();
         nearSubwayStations.addStations(List.of(SubwayStation.of("455", "정왕", 4)));
-        given(odsaySubwayClient.fetchStationInfo("456"))
+        given(clientProcessor.fetchNearStations(any(SubwayStation.class)))
                 .willReturn(nearSubwayStations);
 
         // when
@@ -96,26 +86,29 @@ class SubwayServiceTest { // TODO ServiceTest 생성
         );
     }
 
-    @Disabled // TODO 임시
     @Test
-    void 현재_지하철역과_다음_지하철역으로_지하철_칸별_혼잡도를_조회한다() {
+    void 기준_지하철역과_다음_지하철역으로_지하철_칸별_혼잡도를_조회한다() {
         // given
-        given(dataSeoulSubwayClient.fetchRealTimeSubwayPositions(StationLine.SEOUL_METRO_2))
-                .willReturn(new Subways(
-                        List.of(POSITION_2390, POSITION_2413, POSITION_2373, POSITION_2344, POSITION_2389)));
+        given(clientProcessor.fetchSubwayDirection(any(SubwayStation.class), any(SubwayStation.class)))
+                .willReturn(SubwayDirection.INNER);
 
-        Subway subway = new Subway("2390", null, null, null); // 잠실나루
+        Subways subways = new Subways();
+        subways.add(SUBWAY_2390);
+        subways.add(SUBWAY_2413);
+        subways.add(SUBWAY_2373);
+        subways.add(SUBWAY_2344);
+        subways.add(SUBWAY_2389);
+        given(clientProcessor.fetchRealTimeSubways(any(SubwayStation.class)))
+                .willReturn(subways);
+
         List<Integer> carCongestions = List.of(46, 38, 46, 31, 67, 68, 66, 78, 69, 63);
-        given(skSubwayClient.fetchCongestion(any(Subway.class)))
-                .willReturn(SubwayCongestion.of(subway, 57, carCongestions));
+        given(clientProcessor.fetchSubwayCongestion(any(Subway.class)))
+                .willReturn(SubwayCongestion.of(SUBWAY_2390, 57, carCongestions));
 
         SubwayStation targetStation = SubwayStation.of("229", "봉천", 2);
         SubwayStation nextStation = SubwayStation.of("230", "신림", 2);
-        given(odsaySubwayClient.fetchSubwayPath(any(Subway.class)))
-                .willReturn(new SubwayPath(
-                        new Subway(null, null, targetStation, nextStation),
-                        SubwayDirection.INNER,
-                        List.of(nextStation)));
+        given(clientProcessor.fetchSubwayPath(any(Subway.class)))
+                .willReturn(new SubwayWithPath(SUBWAY_2490, SUBWAY_2490.getDirection(), List.of(targetStation)));
 
         // when
         SubwayCarCongestionsResponse response = subwayService.findSubwayCongestion(targetStation, nextStation);

--- a/src/test/java/com/easyride/subway/service/SubwayServiceTest.java
+++ b/src/test/java/com/easyride/subway/service/SubwayServiceTest.java
@@ -18,6 +18,8 @@ import com.easyride.subway.domain.NearSubwayStations;
 import com.easyride.subway.domain.StationLine;
 import com.easyride.subway.domain.Subway;
 import com.easyride.subway.domain.SubwayCongestion;
+import com.easyride.subway.domain.SubwayDirection;
+import com.easyride.subway.domain.SubwayPath;
 import com.easyride.subway.domain.SubwayStation;
 import com.easyride.subway.domain.SubwayStations;
 import com.easyride.subway.domain.Subways;
@@ -26,6 +28,7 @@ import com.easyride.subway.service.dto.SubwayCarCongestionDetail;
 import com.easyride.subway.service.dto.SubwayCarCongestionsResponse;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -93,6 +96,7 @@ class SubwayServiceTest { // TODO ServiceTest 생성
         );
     }
 
+    @Disabled // TODO 임시
     @Test
     void 현재_지하철역과_다음_지하철역으로_지하철_칸별_혼잡도를_조회한다() {
         // given
@@ -105,10 +109,16 @@ class SubwayServiceTest { // TODO ServiceTest 생성
         given(skSubwayClient.fetchCongestion(any(Subway.class)))
                 .willReturn(SubwayCongestion.of(subway, 57, carCongestions));
 
+        SubwayStation targetStation = SubwayStation.of("229", "봉천", 2);
+        SubwayStation nextStation = SubwayStation.of("230", "신림", 2);
+        given(odsaySubwayClient.fetchSubwayPath(any(Subway.class)))
+                .willReturn(new SubwayPath(
+                        new Subway(null, null, targetStation, nextStation),
+                        SubwayDirection.INNER,
+                        List.of(nextStation)));
+
         // when
-        SubwayCarCongestionsResponse response = subwayService.findSubwayCongestion(
-                SubwayStation.of("229", "봉천", 2),
-                SubwayStation.of("230", "신림", 2));
+        SubwayCarCongestionsResponse response = subwayService.findSubwayCongestion(targetStation, nextStation);
 
         // then
         assertAll(

--- a/src/test/resources/odsay/success/station-path.json
+++ b/src/test/resources/odsay/success/station-path.json
@@ -1,0 +1,167 @@
+{
+  "result": {
+    "globalStartName": "신촌",
+    "globalEndName": "선릉",
+    "globalTravelTime": 43,
+    "globalDistance": 25.4,
+    "globalStationCount": 20,
+    "fare": 1600,
+    "cashFare": 1700,
+    "driveInfoSet": {
+      "driveInfo": [
+        {
+          "laneID": "2",
+          "laneName": "2호선",
+          "startName": "신촌",
+          "stationCount": 20,
+          "wayCode": 1,
+          "wayName": "외선순환"
+        }
+      ]
+    },
+    "stationSet": {
+      "stations": [
+        {
+          "startID": 240,
+          "startName": "신촌",
+          "endSID": 239,
+          "endName": "홍대입구",
+          "travelTime": 2
+        },
+        {
+          "startID": 239,
+          "startName": "홍대입구",
+          "endSID": 238,
+          "endName": "합정",
+          "travelTime": 4
+        },
+        {
+          "startID": 238,
+          "startName": "합정",
+          "endSID": 237,
+          "endName": "당산",
+          "travelTime": 8
+        },
+        {
+          "startID": 237,
+          "startName": "당산",
+          "endSID": 236,
+          "endName": "영등포구청",
+          "travelTime": 10
+        },
+        {
+          "startID": 236,
+          "startName": "영등포구청",
+          "endSID": 235,
+          "endName": "문래",
+          "travelTime": 12
+        },
+        {
+          "startID": 235,
+          "startName": "문래",
+          "endSID": 234,
+          "endName": "신도림",
+          "travelTime": 14
+        },
+        {
+          "startID": 234,
+          "startName": "신도림",
+          "endSID": 233,
+          "endName": "대림",
+          "travelTime": 17
+        },
+        {
+          "startID": 233,
+          "startName": "대림",
+          "endSID": 232,
+          "endName": "구로디지털단지",
+          "travelTime": 19
+        },
+        {
+          "startID": 232,
+          "startName": "구로디지털단지",
+          "endSID": 231,
+          "endName": "신대방",
+          "travelTime": 21
+        },
+        {
+          "startID": 231,
+          "startName": "신대방",
+          "endSID": 230,
+          "endName": "신림",
+          "travelTime": 23
+        },
+        {
+          "startID": 230,
+          "startName": "신림",
+          "endSID": 229,
+          "endName": "봉천",
+          "travelTime": 25
+        },
+        {
+          "startID": 229,
+          "startName": "봉천",
+          "endSID": 228,
+          "endName": "서울대입구",
+          "travelTime": 27
+        },
+        {
+          "startID": 228,
+          "startName": "서울대입구",
+          "endSID": 227,
+          "endName": "낙성대",
+          "travelTime": 29
+        },
+        {
+          "startID": 227,
+          "startName": "낙성대",
+          "endSID": 226,
+          "endName": "사당",
+          "travelTime": 31
+        },
+        {
+          "startID": 226,
+          "startName": "사당",
+          "endSID": 225,
+          "endName": "방배",
+          "travelTime": 34
+        },
+        {
+          "startID": 225,
+          "startName": "방배",
+          "endSID": 224,
+          "endName": "서초",
+          "travelTime": 36
+        },
+        {
+          "startID": 224,
+          "startName": "서초",
+          "endSID": 223,
+          "endName": "교대",
+          "travelTime": 38
+        },
+        {
+          "startID": 223,
+          "startName": "교대",
+          "endSID": 222,
+          "endName": "강남",
+          "travelTime": 40
+        },
+        {
+          "startID": 222,
+          "startName": "강남",
+          "endSID": 221,
+          "endName": "역삼",
+          "travelTime": 42
+        },
+        {
+          "startID": 221,
+          "startName": "역삼",
+          "endSID": 220,
+          "endName": "선릉",
+          "travelTime": 43
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## 👀 관련 이슈
close #15 

## ⭐️ 작업 내용
각 호선별 발생 가능한 엣지케이스를 찾는 과정에서 아래 가설에 논리적 결함이 있음을 알게 되었습니다. 이를 보완하기 위해 추가 API를 연동하였습니다.

### 기존
API 사용을 줄이기 위해 아래 가설을 세워 로직을 구현하였습니다. 그러나 순환 노선(2호선, 6호선)의 경우 지하철역 ID가 증가하는 형태가 아닌 특정 ID 구간을 순환하는 형태이므로 반례가 존재했습니다.

- **지하철의 방향**: 출발 지하철역 ID -> 도착 지하철역 ID의 증감을 고려해 계산
- **내 위치를 지나는 지하철인지**: 내 위치 지하철역 ID가 출발 지하철역 ID와 도착 지하철역 ID 사이에 있는지 계산
- **가장 먼저 내 위치에 진입할 지하철**: 내 위치 지하철역 ID와 지하철 위치 역 ID의 절댓값 차의 최소로 계산

### 변경

1. 오디세이 지하철 경로검색 조회 API 도입
    - 출발역과 도착역 정보를 받아 두 역 사이의 역들과 진행 방향 조회

2. [리팩터링] 기존 클라이언트 클래스 역할 정의
    - 기존: 외부 API에 접근 후 서비스 계층의 입맛에 맞게 도메인을 반환하도록 하였음
    - 문제: 클라이언트가 고정된 도메인을 반환하여 다양한 상황에서 외부 API 응답을 유연하게 사용하기 어려움
    - 변경: 클라이언트에게 오직 외부 API 접근 역할만 부여하기 위해 기존 DTO를 반환하도록 하여, 서비스와 클라이언트 사이 데이터를 가공하는 역할의 ServiceClientProcessor를 추가
    - 이점: 같은 API를 통해 얻은 DTO를 다른 방식으로 변환하여 사용 가능

3. [리팩터링] 도메인에서 역할 덜기
    - 기존: 최대한 도메인을 활용하기 위해 도메인에 비즈니스 로직을 많이 분담함
    - 문제: 서비스 계층은 깔끔하나 일급컬렉션과 같은 클래스의 역할이 혼재됨
    - 변경: 도메인의 비즈니스 로직 일부를 서비스 계층으로 추출함
    - 이점: 예외 처리 위치 및 일급컬렉션의 역할이 더욱 명확해짐

## 🫧 기타

